### PR TITLE
ibm-watsonx-ai integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+*.xml
 
 # Translations
 *.mo

--- a/bigcode_eval/arguments.py
+++ b/bigcode_eval/arguments.py
@@ -18,13 +18,13 @@ class EvalArguments:
         metadata={"help": "Sample from the language model's output distribution."},
     )
     temperature: Optional[float] = field(
-        default=0.2, metadata={"help": "Sampling temperature used for generation."}
+        default=None, metadata={"help": "Sampling temperature used for generation."}
     )
     top_k: Optional[int] = field(
-        default=0, metadata={"help": "Top-k parameter used for generation."}
+        default=None, metadata={"help": "Top-k parameter used for generation."}
     )
     top_p: Optional[float] = field(
-        default=0.95, metadata={"help": "Top-p parameter used for nucleus sampling."}
+        default=None, metadata={"help": "Top-p parameter used for nucleus sampling."}
     )
     n_samples: Optional[int] = field(
         default=1,
@@ -34,5 +34,18 @@ class EvalArguments:
         default="<|endoftext|>", metadata={"help": "end of sentence token."}
     )
     seed: Optional[int] = field(
-        default=0, metadata={"help": "Random seed used for evaluation."}
+        default=None, metadata={"help": "Random seed used for evaluation."}
+    )
+    length_penalty: Optional[dict[str, int | float]] = field(
+        default=None,
+        metadata={"help": "A dictionary with length penalty options."}
+    )
+    max_new_tokens: Optional[int] = field(
+        default=None, metadata={"help": "Maximum number of generated tokens."}
+    )
+    min_new_tokens: Optional[int] = field(
+        default=None, metadata={"help": "Minimum number of generated tokens."}
+    )
+    stop_sequences: Optional[list[str]] = field(
+        default=None, metadata={"help": "List of stop sequences."}
     )

--- a/bigcode_eval/arguments.py
+++ b/bigcode_eval/arguments.py
@@ -49,3 +49,7 @@ class EvalArguments:
     stop_sequences: Optional[list[str]] = field(
         default=None, metadata={"help": "List of stop sequences."}
     )
+    repetition_penalty: Optional[float] = field(
+        default=None,
+        metadata={"help": "A float value of repetition penalty."}
+    )

--- a/bigcode_eval/base.py
+++ b/bigcode_eval/base.py
@@ -9,6 +9,8 @@ class Task(ABC):
     answers, generation settings and evaluation methods.
     """
 
+    LANGUAGE: str = "python"
+
     # The name of the `Task` benchmark as denoted in the HuggingFace datasets Hub
     DATASET_PATH: str = None
 

--- a/bigcode_eval/tasks/codexglue_code_to_text.py
+++ b/bigcode_eval/tasks/codexglue_code_to_text.py
@@ -94,6 +94,7 @@ class GeneralCodeToText(Task):
 
     def __init__(self, language):
         self.DATASET_NAME = language
+        self.LANGUAGE = language
         stop_words = ["'''", '"""'] if language == "python" else ["\n"]
         super().__init__(
             stop_words=stop_words,
@@ -203,7 +204,9 @@ class GeneralCodeToText(Task):
         bleu_score = compute_codexglue_code_to_text_bleu(
             (ref, gen[0]) for ref, gen in zip(references, generations)
         )
-        return {"blue": bleu_score}
+        return {
+            "blue": bleu_score, "language": self.LANGUAGE, "execution_env": ""
+        }
 
 
 class LeftCodeToText(GeneralCodeToText):

--- a/bigcode_eval/tasks/codexglue_text_to_text.py
+++ b/bigcode_eval/tasks/codexglue_text_to_text.py
@@ -121,4 +121,4 @@ class CodexglueTextToText(Task):
         results = bleu.compute(
             references=references, predictions=gens, max_order=self.max_order, smooth=self.smooth
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": ""}

--- a/bigcode_eval/tasks/conala.py
+++ b/bigcode_eval/tasks/conala.py
@@ -32,6 +32,7 @@ class Conala(Task):
     answers, generation settings and evaluation methods.
     """
 
+    LANGUAGE = "python"
     DATASET_PATH = "neulab/conala"
 
     def __init__(self, max_order=4, smooth=True):
@@ -105,4 +106,4 @@ class Conala(Task):
         results = bleu.compute(
             references=references, predictions=gens, max_order=self.max_order, smooth=self.smooth
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": ""}

--- a/bigcode_eval/tasks/concode.py
+++ b/bigcode_eval/tasks/concode.py
@@ -106,4 +106,4 @@ class Concode(Task):
         results = bleu.compute(
             references=references, predictions=gens, max_order=self.max_order, smooth=self.smooth
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": ""}

--- a/bigcode_eval/tasks/custom_metrics/code_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/code_eval.py
@@ -274,7 +274,9 @@ def execute_code_remotely(
 
             status = send_code_exec_request(language, program)
 
-            passed = 1 if status["exit_code"] == 0 else 0
+            passed = 1 if (
+                status["exit_code"] == 0 and len(status["stderr"]) == 0
+            ) else 0
             correct.append(passed)
             total.append(1)
 

--- a/bigcode_eval/tasks/custom_metrics/code_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/code_eval.py
@@ -155,9 +155,14 @@ def compute_code_eval(
 ):
     """Returns the scores"""
 
+    execution_env = (
+        "local" if os.environ.get("EXECUTE_CODE_LOCALLY")
+        else "wxai-code-exec"
+    )
+
     total, correct, results = (
         execute_code_locally(predictions, references, num_workers, timeout)
-        if os.environ.get("EXECUTE_CODE_LOCALLY")
+        if execution_env == "local"
         else execute_code_remotely(predictions, references, language)
     )
 
@@ -169,7 +174,7 @@ def compute_code_eval(
         ks = [ks]
     pass_at_k = {f"pass@{k}": estimate_pass_at_k(total, correct, k).mean() for k in ks if (total >= k).all()}
 
-    return pass_at_k, results
+    return pass_at_k, results, execution_env
 
 
 def estimate_pass_at_k(num_samples, num_correct, k):

--- a/bigcode_eval/tasks/custom_metrics/code_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/code_eval.py
@@ -240,6 +240,7 @@ def send_code_exec_request(
         "Accept": "application/json",
         "Content-Type": "application/json",
     }
+    url = os.getenv("WML_URL_ADDR", url)
 
     response = requests.post(
         url=url,
@@ -274,9 +275,10 @@ def execute_code_remotely(
 
             status = send_code_exec_request(language, program)
 
-            passed = 1 if (
-                status["exit_code"] == 0 and len(status["stderr"]) == 0
-            ) else 0
+            passed = 1 if status["exit_code"] == 0 else 0
+            if language in ["js", "javascript", "java_script"]:
+                passed = 1 if status["stderr"] == "" else 0
+
             correct.append(passed)
             total.append(1)
 

--- a/bigcode_eval/tasks/custom_metrics/code_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/code_eval.py
@@ -145,13 +145,20 @@ class ResStatus(TypedDict):
     status: str
 
 
-def compute_code_eval(predictions, references, k=[1, 10, 100], num_workers=4, timeout=3.0):
+def compute_code_eval(
+    predictions,
+    references,
+    k=[1, 10, 100],
+    num_workers=4,
+    timeout=3.0,
+    language="python",
+):
     """Returns the scores"""
 
     total, correct, results = (
         execute_code_locally(predictions, references, num_workers, timeout)
         if os.environ.get("EXECUTE_CODE_LOCALLY")
-        else execute_code_remotely(predictions, references)
+        else execute_code_remotely(predictions, references, language)
     )
 
     total = np.array(total)
@@ -256,13 +263,10 @@ def send_code_exec_request(
 def execute_code_remotely(
     generated_codes: list[list[str]],
     test_cases: list[str],
+    language: str,
 ) -> CodeExecRes:
     total, correct = [], []
     detailed_results = defaultdict(list)
-
-    # TODO: find a way to reliably determine the language to be used;
-    #  maybe pass it in 'process_results' methods of each task?
-    language = "python"
 
     for task_id, (generated_code, test_case) in enumerate(zip(generated_codes, test_cases)):
         for sample_id, sample in enumerate(generated_code):

--- a/bigcode_eval/tasks/custom_metrics/code_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/code_eval.py
@@ -149,8 +149,9 @@ def compute_code_eval(predictions, references, k=[1, 10, 100], num_workers=4, ti
     """Returns the scores"""
 
     total, correct, results = (
-        execute_code_remotely(predictions, references) if True
-        else execute_code_locally(predictions, references, num_workers, timeout)
+        execute_code_locally(predictions, references, num_workers, timeout)
+        if os.environ.get("EXECUTE_CODE_LOCALLY")
+        else execute_code_remotely(predictions, references)
     )
 
     total = np.array(total)

--- a/bigcode_eval/tasks/ds1000.py
+++ b/bigcode_eval/tasks/ds1000.py
@@ -20,6 +20,7 @@ import requests
 import tqdm
 
 from bigcode_eval.base import Task
+from bigcode_eval.tasks.custom_metrics.code_eval import compute_code_eval
 
 _CITATION = """
 @article{Lai2022DS1000,
@@ -178,14 +179,10 @@ class GeneralDS1000(Task):
             list of str containing refrences
         :return: dict[str: float]
         """
-        dataset = self.get_dataset()
-        num_correct = 0
-        print("Scoring generations...")
-        for i, ref in tqdm.tqdm(enumerate(references), total=len(references)):
-            test = [doc for doc in dataset if doc["reference_code"] == ref][0]
-            for gen in generations[i]:
-                is_correct = test.test(gen)
-                if is_correct:
-                    num_correct += 1
-        accuracy = num_correct / len(references) / len(generations[0])
-        return {f"mean pass@1 accuracy ({len(generations[0])} samples)": accuracy}
+        pass_at_1, _ = compute_code_eval(
+            predictions=generations,
+            references=references,
+            language="python",
+            k=[1],
+        )
+        return pass_at_1

--- a/bigcode_eval/tasks/ds1000.py
+++ b/bigcode_eval/tasks/ds1000.py
@@ -58,6 +58,7 @@ def create_all_tasks():
 
 
 class GeneralDS1000(Task):
+    LANGUAGE = "python"
     DATASET_PATH = None
     DATASET_NAME = None
 
@@ -179,10 +180,12 @@ class GeneralDS1000(Task):
             list of str containing refrences
         :return: dict[str: float]
         """
-        pass_at_1, _ = compute_code_eval(
+        pass_at_1, _, execution_env = compute_code_eval(
             predictions=generations,
             references=references,
             language="python",
             k=[1],
         )
-        return pass_at_1
+        return {
+            **pass_at_1, "language": self.LANGUAGE, "execution_env": execution_env
+        }

--- a/bigcode_eval/tasks/gsm.py
+++ b/bigcode_eval/tasks/gsm.py
@@ -73,6 +73,7 @@ def create_task(cls, evaluation_type):
 
 class Gsm8k(Task):
 
+    LANGUAGE = "python"
     DATASET_PATH = "gsm8k"
     DATASET_NAME = "main"
     POST_SCRIPT = "print(solution())"
@@ -183,7 +184,7 @@ class Gsm8k(Task):
             predictions=generations,
             majority_voting=self.majority_voting,
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": "local"}
 
 
 class GsmHard(Gsm8k):

--- a/bigcode_eval/tasks/humaneval.py
+++ b/bigcode_eval/tasks/humaneval.py
@@ -101,5 +101,6 @@ class GeneralHumanEval(Task):
             k=self.k,
             num_workers=self.num_workers,
             timeout=self.timeout,
+            language="python",
         )
         return results

--- a/bigcode_eval/tasks/humaneval.py
+++ b/bigcode_eval/tasks/humaneval.py
@@ -45,6 +45,7 @@ class GeneralHumanEval(Task):
     answers, generation settings and evaluation methods.
     """
 
+    LANGUAGE = "python"
     DATASET_PATH = "openai_humaneval"
 
     def __init__(self, strip_prompt, k=[1, 10, 100], num_workers=16, timeout=3.0):
@@ -95,7 +96,7 @@ class GeneralHumanEval(Task):
         :param references: list(str)
             list of str containing refrences
         """
-        results, _ = compute_code_eval(
+        results, _, execution_env = compute_code_eval(
             references=references,
             predictions=generations,
             k=self.k,
@@ -103,4 +104,4 @@ class GeneralHumanEval(Task):
             timeout=self.timeout,
             language="python",
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -185,6 +185,7 @@ class HumanEvalPack(Task):
     def __init__(self, prompt="instruct", language="python", with_docs=True):
         
         self.DATASET_NAME = language
+        self.LANGUAGE = language
         self.prompt = prompt        
         stop_words = LANGUAGE_TO_STOP_WORDS[language]
         if self.prompt.startswith("edit"):
@@ -514,7 +515,7 @@ class HumanEvalPackGenerative(HumanEvalPack):
                     gen[i] = new_gen
 
         ### EVALUATION ###
-        results, logs = compute_code_eval(
+        results, logs, execution_env = compute_code_eval(
             predictions=generations,
             references=references,
             timeout=timeout,
@@ -548,7 +549,7 @@ class HumanEvalPackGenerative(HumanEvalPack):
                 print("Ref")
                 print(ref)
         """
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}
 
 
 class HumanEvalFixBase(HumanEvalPackGenerative):

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -28,6 +28,7 @@ You MUST follow these guidelines:
  - You are an AI assistant: do NOT claim to be a person. You are a computer program. You are NOT and CANNOT be self-awareness or consciousness.
  - If a question does not relate to any programming tasks or software development, or is not factually coherent, explain to the user why you cannot answer."""
 
+system_mixtral = "Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity.\n\n"
 LANGUAGES = ["python", "cpp", "js", "java", "go", "rust"]
 
 LANGUAGE_TO_NAME = {
@@ -232,6 +233,8 @@ class HumanEvalPack(Task):
             prompt = f'Question:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "octocoder_system":
             prompt = f'System:\n{system}\n\nQuestion:\n{inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "mixtral_system":
+            prompt = f'System:\n{system_mixtral}Question:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "octogeex":
             prompt = f'Question: {inp.strip()}\n\nAnswer:\n{prompt_base}'            
         elif self.prompt == "starchat":
@@ -426,7 +429,10 @@ class HumanEvalPackGenerative(HumanEvalPack):
                 [g.replace("public class Main {\n    }", "").strip() for g in gen] for gen in generations
             ]
         elif language == "go":
-            ds = self.get_dataset().select(range(len(generations)))
+            ds = self.get_dataset()
+            if not isinstance(ds, list):
+                ds = ds.select(range(len(generations)))
+            
             for gen, ref, doc in zip(generations, references, ds):
                 for line in doc["import"].split("\n"):
                     line = line.replace("import", "").replace("(", "").replace(")", "").replace('"', "").strip()
@@ -462,7 +468,10 @@ class HumanEvalPackGenerative(HumanEvalPack):
                         gen[i] = gen[i].replace("package main", "")
                     gen[i] = test_setup_str + other_pkgs_str + gen[i]
         elif language == "rust":
-            ds = self.get_dataset().select(range(len(generations)))
+            ds = self.get_dataset()
+            if not isinstance(ds, list):
+                ds = ds.select(range(len(generations)))
+
             main = "fn main(){}\n"
             for gen, doc in zip(generations, ds):
                 declaration = doc["declaration"]

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -29,6 +29,12 @@ You MUST follow these guidelines:
  - If a question does not relate to any programming tasks or software development, or is not factually coherent, explain to the user why you cannot answer."""
 
 system_mixtral = "Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity.\n\n"
+system_granite_three = """Knowledge Cutoff Date: April 2024.
+Today's Date: December 13, 2024.
+
+You are Granite, developed by IBM. You are a helpful AI assistant.
+"""
+system_llama_three = """You are a helpful assistant that avoids causing harm. When you do not know the answer to a question, you say "I don't know"."""
 LANGUAGES = ["python", "cpp", "js", "java", "go", "rust"]
 
 LANGUAGE_TO_NAME = {
@@ -235,6 +241,19 @@ class HumanEvalPack(Task):
             prompt = f'System:\n{system}\n\nQuestion:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "mixtral_system":
             prompt = f'System:\n{system_mixtral}Question:\n{inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "granite_three":
+            prompt = (
+                f"<|start_of_role|>system<|end_of_role|>{system_granite_three}<|end_of_text|>\n"
+                + f"<|start_of_role|>user<|end_of_role|>{inp}<|end_of_text|>\n"
+                + f"<|start_of_role|>assistant<|end_of_role|>\n{prompt_base}"
+            )
+        elif self.prompt == "llama_three":
+            prompt = (
+                f"<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n"
+                + f"{system_llama_three}<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n"
+                + f"{inp}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+                + f"{prompt_base}"
+            )
         elif self.prompt == "octogeex":
             prompt = f'Question: {inp.strip()}\n\nAnswer:\n{prompt_base}'            
         elif self.prompt == "starchat":

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -432,6 +432,8 @@ class HumanEvalPackGenerative(HumanEvalPack):
             ds = self.get_dataset()
             if not isinstance(ds, list):
                 ds = ds.select(range(len(generations)))
+            else:
+                ds = ds[:len(generations)]
             
             for gen, ref, doc in zip(generations, references, ds):
                 for line in doc["import"].split("\n"):
@@ -471,6 +473,8 @@ class HumanEvalPackGenerative(HumanEvalPack):
             ds = self.get_dataset()
             if not isinstance(ds, list):
                 ds = ds.select(range(len(generations)))
+            else:
+                ds = ds[:len(generations)]
 
             main = "fn main(){}\n"
             for gen, doc in zip(generations, ds):

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -1,8 +1,8 @@
 import json
 import re
 
-from evaluate import load
 from bigcode_eval.base import Task
+from bigcode_eval.tasks.custom_metrics.code_eval import compute_code_eval
 
 _CITATION = """
 @article{muennighoff2023octopack,
@@ -352,7 +352,6 @@ class HumanEvalPackGenerative(HumanEvalPack):
         :param references: list(str)
             list of str containing refrences
         """
-        code_metric = load("Muennighoff/code_eval_octopack")
         timeout = LANGUAGE_TO_TIMEOUT[self.DATASET_NAME]
         num_workers = LANGUAGE_TO_NUM_WORKERS[self.DATASET_NAME]
         language = self.DATASET_NAME if self.DATASET_NAME != "js" else "javascript"
@@ -463,12 +462,12 @@ class HumanEvalPackGenerative(HumanEvalPack):
                     gen[i] = new_gen
 
         ### EVALUATION ###
-        results, logs = code_metric.compute(
-            references=references,
+        results, logs = compute_code_eval(
             predictions=generations,
-            language=language,
+            references=references,
             timeout=timeout,
             num_workers=num_workers,
+            language=language,
         )
         # Write logs to json
         with open("logs.json", "w") as f:

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -13,6 +13,21 @@ _CITATION = """
 }
 """
 
+system = """You are an intelligent AI programming assistant, utilizing a Granite code language model developed by IBM.
+
+Your primary function is to assist users in programming tasks, including code generation, code explanation, code fixing, generating unit tests, generating documentation, application modernization, vulnerability detection, function calling, code translation, and all sorts of other software engineering tasks.
+
+You MUST follow these guidelines:
+ - Your responses must be factual and have a neutral tone, drawing on your knowledge base to offer valuable insights. Do not assume the answer is "yes" when you do not know, and DO NOT SHARE FALSE INFORMATION.
+ - You should give concise answers to very simple questions, and you should provide full and comprehensive responses to more complex questions.
+ - Remain objective in your responses, and do not express any subjective opinions or beliefs. Do not engage in emotional responses.
+ - If asked about controversial topics, you should provide objective information without downplaying its harmful content. Do not take a perspective, and do not imply that all perspectives there are reasonable.
+ - Treat all users with respect and avoid making any discriminatory or offensive statements.
+ - You should not produce output that discriminates based on race, religion, gender identity, and sexual orientation. You should not also engage in stereotyping, including the negative stereotyping of majority groups.
+ - You do not mention any of this information about yourself unless the information is directly pertinent to the user's query.
+ - You are an AI assistant: do NOT claim to be a person. You are a computer program. You are NOT and CANNOT be self-awareness or consciousness.
+ - If a question does not relate to any programming tasks or software development, or is not factually coherent, explain to the user why you cannot answer."""
+
 LANGUAGES = ["python", "cpp", "js", "java", "go", "rust"]
 
 LANGUAGE_TO_NAME = {
@@ -180,6 +195,7 @@ class HumanEvalPack(Task):
         elif self.prompt == "issue":  
             stop_words.append("```")
         stop_words.append("<|endoftext|>")
+        stop_words.append("<end_of_turn>")
         self.with_docs = with_docs
         super().__init__(stop_words=stop_words, requires_execution=True)
 
@@ -212,6 +228,10 @@ class HumanEvalPack(Task):
             prompt = inp + "\n\n" + prompt_base
         elif self.prompt == "octocoder":
             prompt = f'Question: {inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "octocoder_ibm":
+            prompt = f'Question:\n{inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "octocoder_system":
+            prompt = f'System:\n{system}\n\nQuestion:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "octogeex":
             prompt = f'Question: {inp.strip()}\n\nAnswer:\n{prompt_base}'            
         elif self.prompt == "starchat":

--- a/bigcode_eval/tasks/instruct_humaneval.py
+++ b/bigcode_eval/tasks/instruct_humaneval.py
@@ -64,12 +64,12 @@ class InstructHumanEval(Task):
         :param references: list(str)
             list of str containing references
         """
-        results, _ = compute_code_eval(
+        results, _, execution_env = compute_code_eval(
             references=references,
             predictions=generations,
             language="python",
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}
 
 
 class InstructHumanEvalWithContext(InstructHumanEval):

--- a/bigcode_eval/tasks/instruct_humaneval.py
+++ b/bigcode_eval/tasks/instruct_humaneval.py
@@ -67,6 +67,7 @@ class InstructHumanEval(Task):
         results, _ = compute_code_eval(
             references=references,
             predictions=generations,
+            language="python",
         )
         return results
 

--- a/bigcode_eval/tasks/instruct_wizard_humaneval.py
+++ b/bigcode_eval/tasks/instruct_wizard_humaneval.py
@@ -117,5 +117,6 @@ class HumanEvalWizardCoder(Task):
         results, _ = compute_code_eval(
             references=references,
             predictions=generations,
+            language="python",
         )
         return results

--- a/bigcode_eval/tasks/instruct_wizard_humaneval.py
+++ b/bigcode_eval/tasks/instruct_wizard_humaneval.py
@@ -114,9 +114,9 @@ class HumanEvalWizardCoder(Task):
         :param references: list(str)
             list of str containing refrences
         """
-        results, _ = compute_code_eval(
+        results, _, execution_env = compute_code_eval(
             references=references,
             predictions=generations,
             language="python",
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/mbpp.py
+++ b/bigcode_eval/tasks/mbpp.py
@@ -82,5 +82,6 @@ class MBPP(Task):
         results, _ = compute_code_eval(
             references=references,
             predictions=generations,
+            language="python",
         )
         return results

--- a/bigcode_eval/tasks/mbpp.py
+++ b/bigcode_eval/tasks/mbpp.py
@@ -28,6 +28,7 @@ class MBPP(Task):
     answers, generation settings and evaluation methods.
     """
 
+    LANGUAGE = "python"
     DATASET_PATH = "mbpp"
 
     def __init__(self):
@@ -79,9 +80,9 @@ class MBPP(Task):
         :param references: list(str)
             list of str containing refrences
         """
-        results, _ = compute_code_eval(
+        results, _, execution_env = compute_code_eval(
             references=references,
             predictions=generations,
             language="python",
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/mbppplus.py
+++ b/bigcode_eval/tasks/mbppplus.py
@@ -66,10 +66,10 @@ class MBPPPlus(MBPP):
         :param references: list(str)
             list of str containing refrences
         """
-        results, _ = compute_code_eval(
+        results, _, execution_env = compute_code_eval(
             references=references,
             predictions=generations,
             timeout=10.0,  # 10s timeout
             language="python",
         )
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/mbppplus.py
+++ b/bigcode_eval/tasks/mbppplus.py
@@ -70,5 +70,6 @@ class MBPPPlus(MBPP):
             references=references,
             predictions=generations,
             timeout=10.0,  # 10s timeout
+            language="python",
         )
         return results

--- a/bigcode_eval/tasks/mercury.py
+++ b/bigcode_eval/tasks/mercury.py
@@ -27,6 +27,7 @@ class Mercury(Task):
     answers, generation settings and evaluation methods.
     """
 
+    LANGUAGE = "python"
     DATASET_PATH = "Elfsong/Mercury"
 
     def __init__(self, prompt):
@@ -103,4 +104,4 @@ class Mercury(Task):
         
         results = compute_beyond_eval(generations, references)
         
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": "local"}

--- a/bigcode_eval/tasks/multiple.py
+++ b/bigcode_eval/tasks/multiple.py
@@ -83,6 +83,7 @@ class GeneralMultiPLE(Task):
 
     def __init__(self, language):
         self.language = language
+        self.LANGUAGE = language
         self.DATASET_NAME = f"humaneval-{language}"
         # we need the dataset to get stop words for each language
         self.dataset = load_dataset(
@@ -136,11 +137,11 @@ class GeneralMultiPLE(Task):
             list of str containing refrences
         """
 
-        pass_at_k, _ = compute_code_eval(
+        pass_at_k, _, execution_env = compute_code_eval(
             predictions=generations,
             references=references,
             language=self.language,
             k=[1, 10, 100],
         )
 
-        return pass_at_k
+        return {**pass_at_k, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/multiple.py
+++ b/bigcode_eval/tasks/multiple.py
@@ -7,23 +7,13 @@ It takes the OpenAI "HumanEval" and the MBPP Python benchmarks and uses little c
 Homepage: https://nuprl.github.io/MultiPL-E/
 """
 
-import json
-import os
 import re
-import tempfile
-from multiprocessing import cpu_count
-from pathlib import Path
-from time import time
 
-import numpy as np
 from datasets import load_dataset
-from tqdm import tqdm
 
 from bigcode_eval.base import Task
-from bigcode_eval.tasks.custom_metrics.multiple_metrics.evaluation import \
-    evaluate_problem
-from bigcode_eval.tasks.custom_metrics.multiple_metrics.single_experiment_pass_k import \
-    for_file
+from bigcode_eval.tasks.custom_metrics.code_eval import compute_code_eval
+
 
 _CITATION = """
 @article{cassano2022scalable,
@@ -145,52 +135,12 @@ class GeneralMultiPLE(Task):
         :param references: list(str)
             list of str containing refrences
         """
-        # get prompts and problem names
-        prompts_names = [
-            {"prompt": doc["prompt"], "name": doc["name"]}
-            for i, doc in enumerate(self.get_dataset())
-            if i < len(generations)
-        ]
-        # a common temp dir for all the problems
-        temp_dir = tempfile.gettempdir()
-        list_files = []
-        for (prompt_name, generation, reference) in zip(
-            prompts_names, generations, references
-        ):
-            problem = {
-                "name": prompt_name["name"],
-                "language": self.language,
-                "prompt": prompt_name["prompt"],
-                "completions": generation,
-                "tests": reference,
-            }
-            # each problem is save in a json file
-            temp_file_name = os.path.join(temp_dir, f"{prompt_name['name']}.json")
-            list_files.append(temp_file_name)
-            with open(temp_file_name, "wt") as f:
-                json.dump(problem, f)
-        print(
-            f"Saved {len(list_files)} problems in {temp_dir} for evaluation, each problem has {len(generations[0])} completions"
+
+        pass_at_k, _ = compute_code_eval(
+            predictions=generations,
+            references=references,
+            language=self.language,
+            k=[1, 10, 100],
         )
 
-        # execute the problems to evaluate them
-        max_workers = cpu_count() - 1 if cpu_count() > 1 else 1
-        for file in tqdm(list_files):
-            evaluate_problem(temp_dir, file, max_workers)
-
-        # compute pass@k scores
-        result_array = np.array(
-            [for_file(p) for p in Path(temp_dir).glob("*.results.json")]
-        )
-        result = result_array.mean(axis=0)
-        name = (
-            temp_dir.split("/")[-1]
-            if temp_dir.split("/")[-1] != ""
-            else temp_dir.split("/")[-2]
-        )
-        results = {
-            f"pass@{k}": v
-            for k, v in zip([1, 10, 100], result)
-            if k <= len(generations[0])
-        }
-        return results
+        return pass_at_k

--- a/bigcode_eval/tasks/parity.py
+++ b/bigcode_eval/tasks/parity.py
@@ -69,6 +69,8 @@ def parity_reference(b1, b2, b3, b4):
 
 
 class Parity(Task):
+    LANGUAGE = "python"
+
     def __init__(self, prompt="prompt"):
 
         super().__init__(
@@ -131,10 +133,10 @@ class Parity(Task):
         out = {}
         # Compute metrics for each number of bugs
         for idx, gens in tqdm.tqdm(enumerate(generations), total=len(generations)):
-            results, _ = compute_code_eval(
+            results, _, execution_env = compute_code_eval(
                 references=[self.parity_tests for _ in gens],
                 predictions=[[g] for g in gens],
                 language="python",
             )
             out[f"{idx+1} bugs"] = results
-        return out
+        return {**out, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/parity.py
+++ b/bigcode_eval/tasks/parity.py
@@ -134,6 +134,7 @@ class Parity(Task):
             results, _ = compute_code_eval(
                 references=[self.parity_tests for _ in gens],
                 predictions=[[g] for g in gens],
+                language="python",
             )
             out[f"{idx+1} bugs"] = results
         return out

--- a/bigcode_eval/tasks/python_bugs.py
+++ b/bigcode_eval/tasks/python_bugs.py
@@ -67,6 +67,7 @@ def mutate_code(input_code, task, prompt="prompt"):
 
 class PythonBugs(Task):
 
+    LANGUAGE = "python"
     DATASET_PATH = "Muennighoff/python-bugs"
 
     def __init__(self, prompt="prompt"):
@@ -125,4 +126,4 @@ class PythonBugs(Task):
             for gen in generations[i]:
                 num_correct += int(gen == ref)
         accuracy = num_correct / len(references) / len(generations[0])
-        return {"mean exact match": accuracy}
+        return {"mean exact match": accuracy, "language": self.LANGUAGE, "execution_env": ""}

--- a/bigcode_eval/tasks/quixbugs.py
+++ b/bigcode_eval/tasks/quixbugs.py
@@ -18,6 +18,7 @@ _CITATION = """
 
 class QuixBugs(Task):
 
+    LANGUAGE = "python"
     DATASET_PATH = "Muennighoff/quixbugs"
 
     def __init__(self, prompt="prompt"):
@@ -118,7 +119,7 @@ class QuixBugs(Task):
         """
         results = {}
         for i, (gen, (name, ref)) in enumerate(zip(generations, references)):
-            sub_results, _ = compute_code_eval(
+            sub_results, _, execution_env = compute_code_eval(
                 references=[ref],
                 predictions=[gen],
                 timeout=10, # Levenshtein distance is slow
@@ -131,4 +132,4 @@ class QuixBugs(Task):
                 k: sum(v[k] for v in results.values()) / len(results) for k in results[list(results.keys())[0]]
             }
             results["num_correct"] = results["all"]["pass@1"] * (len(results) - 1) # -1 for the all metric
-        return results
+        return {**results, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/quixbugs.py
+++ b/bigcode_eval/tasks/quixbugs.py
@@ -122,6 +122,7 @@ class QuixBugs(Task):
                 references=[ref],
                 predictions=[gen],
                 timeout=10, # Levenshtein distance is slow
+                language="python",
             )
             results[name] = sub_results
         # Provide average of all metrics computed

--- a/bigcode_eval/tasks/recode.py
+++ b/bigcode_eval/tasks/recode.py
@@ -125,6 +125,7 @@ class GeneralPerturbedHumanEval(Task):
         _, detailed_results = compute_code_eval(
             references=[ref["test_code"] for ref in references],
             predictions=generations,
+            language="python",
         )
 
         # Compute robust-pass-at-1. For each transformation and each prompt, we have s=5 randomly perturbed prompts.

--- a/bigcode_eval/tasks/recode.py
+++ b/bigcode_eval/tasks/recode.py
@@ -48,6 +48,7 @@ def create_task(category, num_seeds):
 
 
 class GeneralPerturbedHumanEval(Task):
+    LANGUAGE = "python"
     DATASET_PATH = "RaymondLi/perturbed_humaneval"
 
     def __init__(self, category, num_seeds):
@@ -122,7 +123,7 @@ class GeneralPerturbedHumanEval(Task):
         :return: dict[str: float]
         """
 
-        _, detailed_results = compute_code_eval(
+        _, detailed_results, execution_env = compute_code_eval(
             references=[ref["test_code"] for ref in references],
             predictions=generations,
             language="python",
@@ -172,4 +173,4 @@ class GeneralPerturbedHumanEval(Task):
             rp1[transformation] = res
 
         # TODO: for overall-performance, a prompt is solved if correct over the s prompts for all transformation categories.
-        return rp1
+        return {**rp1, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/tasks/studenteval.py
+++ b/bigcode_eval/tasks/studenteval.py
@@ -84,6 +84,7 @@ def _get_group(item):
 
 
 class StudentEval(Task):
+    LANGUAGE = "python"
     DATASET_PATH = "wellesley-easel/StudentEval"
 
     def __init__(self):
@@ -132,7 +133,7 @@ class StudentEval(Task):
             list of reference solutions
         """
 
-        _, detailed_results = compute_code_eval(
+        _, detailed_results, execution_env = compute_code_eval(
             predictions=generations,
             references=[reference["assertions"] for reference in references],
             k=1,
@@ -141,4 +142,4 @@ class StudentEval(Task):
         # TODO: They also calculated mean pass@1 for each group (reference['group']),
         #  do we need that as well?
 
-        return detailed_results
+        return {**detailed_results, "language": self.LANGUAGE, "execution_env": execution_env}

--- a/bigcode_eval/wx_ai.py
+++ b/bigcode_eval/wx_ai.py
@@ -180,9 +180,7 @@ class WxInference:
     ) -> list[list[str]]:
         if instruction_tokens:
             predictions = [
-                _parse_instruction(
-                    prediction[0], instruction_tokens.split(",")
-                )
+                [_parse_instruction(prediction[0], instruction_tokens.split(","))]
                 for prediction in predictions
             ]
 

--- a/bigcode_eval/wx_ai.py
+++ b/bigcode_eval/wx_ai.py
@@ -1,5 +1,5 @@
 from argparse import Namespace
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 from datasets import Dataset
 from ibm_watsonx_ai import APIClient
@@ -7,6 +7,7 @@ from ibm_watsonx_ai.foundation_models import ModelInference
 from unitxt.inference import WMLInferenceEngineBase
 
 from bigcode_eval.base import Task
+from bigcode_eval.utils import _parse_instruction
 
 
 class WxInference:
@@ -21,35 +22,18 @@ class WxInference:
         )
 
     @staticmethod
-    def get_stop_sequences_for_wx(args: Namespace, task: Task) -> Optional[list[str]]:
-        # TODO
-        stop_sequences = []
-
-        if isinstance(task.stop_words, Iterable):
-            stop_sequences.extend(task.stop_words)
-        elif task.stop_words is not None:
-            stop_sequences.append(task.stop_words)
-
-        if args.instruction_tokens:
-            for token in args.instruction_tokens.split(","):
-                if token.strip() != "":
-                    stop_sequences.append(token)
-
-        return stop_sequences if stop_sequences else None
-
-    @staticmethod
     def prepare_wx_gen_params(args: Namespace) -> dict[str, Any]:
-        # TODO: need more generation params?
-        # TODO: HF also uses more "sophisticated" stop criteria than stop words
-        params = {
+        return {
             "decoding_method": "sample" if args.do_sample else "greedy",
+            "random_seed": args.seed,
             "temperature": args.temperature,
             "top_p": args.top_p,
             "top_k": args.top_k,
-            "max_new_tokens": args.max_length_generation,  # wx only has "max_new_tokens"
+            "max_new_tokens": args.max_new_tokens,
+            "min_new_tokens": args.min_new_tokens,
+            "length_penalty": args.length_penalty,
+            "stop_sequences": args.stop_sequences,
         }
-
-        return params
 
     def initialize_wx_model(self, model_name: str) -> ModelInference:
         return ModelInference(
@@ -58,10 +42,58 @@ class WxInference:
         )
 
     @staticmethod
-    def prepare_inputs(dataset: Dataset, task: Task) -> list[str]:
+    def create_prompt_from_dict(
+        prompt_content: dict[str, str],
+        prefix: str,
+        instruction_tokens: Optional[list[str]],
+    ) -> str:
+        if all(key in ("instruction", "context") for key in prompt_content):
+            user_token, end_token, assistant_token = "", "", "\n"
+            if instruction_tokens:
+                user_token, end_token, assistant_token = instruction_tokens
+
+            return "".join(
+                (
+                    prefix,
+                    user_token,
+                    prompt_content["instruction"],
+                    end_token,
+                    assistant_token,
+                    prompt_content["context"],
+                )
+            )
+
+        # Infilling mode is only used for particular models, none of which is available in wx.
+        elif all(key in ("prefix", "suffix") for key in prompt_content):
+            return f"{prefix}{prompt_content['prefix']}{prompt_content['suffix']}"
+
+        else:
+            raise ValueError(
+                f"Unsupported prompt format: '{prompt_content}'."
+            )
+
+    def prepare_inputs(
+        self,
+        dataset: Dataset,
+        task: Task,
+        prefix: str,
+        instruction_tokens: Optional[list[str]],
+    ) -> list[str]:
+        sample = task.get_prompt(dataset[0])
+
+        assert isinstance(sample, (str, dict)), (
+            f"Prompt must be either a string, or a dictionary. "
+            f"However, '{sample}' was given, which is "
+            f"of type: '{type(sample)}'."
+        )
+
         return [
-            task.get_prompt(sample)
-            for sample in dataset
+            prefix + task.get_prompt(instance)
+            if isinstance(sample, str)
+            else self.create_prompt_from_dict(
+                task.get_prompt(instance), prefix, instruction_tokens
+            )
+            for instance in dataset
         ]
 
     def infer(
@@ -69,32 +101,54 @@ class WxInference:
         dataset: Dataset,
         task: Task,
         args: Namespace,
+        prefix: str = "",
         postprocess: bool = True,
-    ) -> list[str]:
+    ) -> list[list[str]]:
         gen_params = self.prepare_wx_gen_params(args)
-        # gen_params["stop_sequences"] = self.get_stop_sequences_for_wx(
-        #     args, task
-        # )
 
         model = self.initialize_wx_model(args.model)
 
+        prompts = self.prepare_inputs(
+            dataset, task, prefix, args.instruction_tokens
+        )
+
         predictions = [
-            result["results"][0]["generated_text"]
+            [result["results"][0]["generated_text"]]
             for result in
             model.generate(
-                prompt=self.prepare_inputs(dataset, task),
+                prompt=prompts,
                 params=gen_params,
             )
         ]
 
         if postprocess:
-            predictions = self.postprocess_predictions(predictions, task)
+            predictions = self.postprocess_predictions(
+                predictions,
+                prompts,
+                task,
+                args.instruction_tokens,
+            )
 
         return predictions
 
     @staticmethod
-    def postprocess_predictions(predictions: list[str], task: Task) -> list[str]:
+    def postprocess_predictions(
+        predictions: list[list[str]],
+        prompts: list[str],
+        task: Task,
+        instruction_tokens: Optional[list[str]],
+    ) -> list[list[str]]:
+        if instruction_tokens:
+            predictions = [
+                _parse_instruction(prediction, instruction_tokens)
+                for prediction in predictions
+            ]
+
         return [
-            task.postprocess_generation(prediction, idx)
-            for idx, prediction in enumerate(predictions)
+            [
+                task.postprocess_generation(
+                    prompts[i] + predictions[i][0], i
+                )
+            ]
+            for i in range(len(predictions))
         ]

--- a/bigcode_eval/wx_ai.py
+++ b/bigcode_eval/wx_ai.py
@@ -1,0 +1,100 @@
+from argparse import Namespace
+from typing import Any, Iterable, Optional
+
+from datasets import Dataset
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models import ModelInference
+from unitxt.inference import WMLInferenceEngineBase
+
+from bigcode_eval.base import Task
+
+
+class WxInference:
+    def __init__(self):
+        wx_creds = WMLInferenceEngineBase._read_wml_credentials_from_env()
+        WMLInferenceEngineBase._verify_wml_credentials(wx_creds)
+
+        self.client = APIClient(
+            project_id=wx_creds.pop("project_id", None),
+            space_id=wx_creds.pop("space_id", None),
+            credentials=wx_creds,
+        )
+
+    @staticmethod
+    def get_stop_sequences_for_wx(args: Namespace, task: Task) -> Optional[list[str]]:
+        # TODO
+        stop_sequences = []
+
+        if isinstance(task.stop_words, Iterable):
+            stop_sequences.extend(task.stop_words)
+        elif task.stop_words is not None:
+            stop_sequences.append(task.stop_words)
+
+        if args.instruction_tokens:
+            for token in args.instruction_tokens.split(","):
+                if token.strip() != "":
+                    stop_sequences.append(token)
+
+        return stop_sequences if stop_sequences else None
+
+    @staticmethod
+    def prepare_wx_gen_params(args: Namespace) -> dict[str, Any]:
+        # TODO: need more generation params?
+        # TODO: HF also uses more "sophisticated" stop criteria than stop words
+        params = {
+            "decoding_method": "sample" if args.do_sample else "greedy",
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "top_k": args.top_k,
+            "max_new_tokens": args.max_length_generation,  # wx only has "max_new_tokens"
+        }
+
+        return params
+
+    def initialize_wx_model(self, model_name: str) -> ModelInference:
+        return ModelInference(
+            model_id=model_name,
+            api_client=self.client,
+        )
+
+    @staticmethod
+    def prepare_inputs(dataset: Dataset, task: Task) -> list[str]:
+        return [
+            task.get_prompt(sample)
+            for sample in dataset
+        ]
+
+    def infer(
+        self,
+        dataset: Dataset,
+        task: Task,
+        args: Namespace,
+        postprocess: bool = True,
+    ) -> list[str]:
+        gen_params = self.prepare_wx_gen_params(args)
+        # gen_params["stop_sequences"] = self.get_stop_sequences_for_wx(
+        #     args, task
+        # )
+
+        model = self.initialize_wx_model(args.model)
+
+        predictions = [
+            result["results"][0]["generated_text"]
+            for result in
+            model.generate(
+                prompt=self.prepare_inputs(dataset, task),
+                params=gen_params,
+            )
+        ]
+
+        if postprocess:
+            predictions = self.postprocess_predictions(predictions, task)
+
+        return predictions
+
+    @staticmethod
+    def postprocess_predictions(predictions: list[str], task: Task) -> list[str]:
+        return [
+            task.postprocess_generation(prediction, idx)
+            for idx, prediction in enumerate(predictions)
+        ]

--- a/bigcode_eval/wx_ai.py
+++ b/bigcode_eval/wx_ai.py
@@ -1,13 +1,16 @@
 from argparse import Namespace
 from typing import Any, Optional
 
-from datasets import Dataset
+from datasets import Dataset as HfDataset
 from ibm_watsonx_ai import APIClient
 from ibm_watsonx_ai.foundation_models import ModelInference
 from unitxt.inference import WMLInferenceEngineBase
 
 from bigcode_eval.base import Task
 from bigcode_eval.utils import _parse_instruction
+
+
+Dataset = HfDataset | list[dict[str, Any]]
 
 
 class WxInference:
@@ -92,10 +95,18 @@ class WxInference:
             )
 
         if offset:
-            dataset = dataset.select(range(offset, len(dataset)))
+            dataset = (
+                dataset.select(range(offset, len(dataset)))
+                if isinstance(dataset, HfDataset)
+                else dataset[offset:]
+            )
 
         if limit:
-            dataset = dataset.take(limit)
+            dataset = (
+                dataset.take(limit)
+                if isinstance(dataset, HfDataset)
+                else dataset[:limit]
+            )
 
         return dataset
 

--- a/main.py
+++ b/main.py
@@ -46,8 +46,9 @@ def parse_args():
     )
     parser.add_argument(
         "--modeltype",
-        default="causal",
-        help="AutoModel to use, it can be causal or seq2seq",
+        default="wx",
+        help="Type of model to use for inference. Can be either any valid watsonx.ai model, "
+             "or HuggingFace AutoModel. In case of the latter, it can be causal or seq2seq.",
     )
     parser.add_argument(
         "--peft_model",
@@ -253,112 +254,115 @@ def main():
             results[task] = evaluator.evaluate(task)
     else:
         # here we generate code and save it (evaluation is optional but True by default)
-        dict_precisions = {
-            "fp32": torch.float32,
-            "fp16": torch.float16,
-            "bf16": torch.bfloat16,
-        }
-        if args.precision not in dict_precisions:
-            raise ValueError(
-                f"Non valid precision {args.precision}, choose from: fp16, fp32, bf16"
-            )
+        model, tokenizer = None, None
 
-        model_kwargs = {
-            "revision": args.revision,
-            "trust_remote_code": args.trust_remote_code,
-            "token": args.use_auth_token,
-        }
-        if args.load_in_8bit:
-            print("Loading model in 8bit")
-            model_kwargs["load_in_8bit"] = args.load_in_8bit
-            model_kwargs["device_map"] = {"": accelerator.process_index}
-        elif args.load_in_4bit:
-            print("Loading model in 4bit")
-            model_kwargs["load_in_4bit"] = args.load_in_4bit
-            model_kwargs["torch_dtype"] = torch.float16
-            model_kwargs["bnb_4bit_compute_dtype"] = torch.float16            
-            model_kwargs["device_map"] = {"": accelerator.process_index}
-        else:
-            print(f"Loading model in {args.precision}")
-            model_kwargs["torch_dtype"] = dict_precisions[args.precision]
+        if args.modeltype != "wx":
+            dict_precisions = {
+                "fp32": torch.float32,
+                "fp16": torch.float16,
+                "bf16": torch.bfloat16,
+            }
+            if args.precision not in dict_precisions:
+                raise ValueError(
+                    f"Non valid precision {args.precision}, choose from: fp16, fp32, bf16"
+                )
 
-            if args.max_memory_per_gpu:
-                if args.max_memory_per_gpu != "auto":
-                    model_kwargs["max_memory"] = get_gpus_max_memory(
-                        args.max_memory_per_gpu, accelerator.num_processes
-                    )
-                    model_kwargs["offload_folder"] = "offload"
-                else:
-                    model_kwargs["device_map"] = "auto"
-                    print("Loading model in auto mode")
-
-        if args.modeltype == "causal":
-            model = AutoModelForCausalLM.from_pretrained(
-                args.model,
-                **model_kwargs,
-            )
-        elif args.modeltype == "seq2seq":
-            warnings.warn(
-                "Seq2Seq models have only been tested for HumanEvalPack & CodeT5+ models."
-            )
-            model = AutoModelForSeq2SeqLM.from_pretrained(
-                args.model,
-                **model_kwargs,
-            )
-        else:
-            raise ValueError(
-                f"Non valid modeltype {args.modeltype}, choose from: causal, seq2seq"
-            )
-
-        if args.peft_model:
-            from peft import PeftModel  # dynamic import to avoid dependency on peft
-
-            model = PeftModel.from_pretrained(model, args.peft_model)
-            print("Loaded PEFT model. Merging...")
-            model.merge_and_unload()
-            print("Merge complete.")
-
-        if args.left_padding:
-            # left padding is required for some models like chatglm3-6b
-            tokenizer = AutoTokenizer.from_pretrained(
-                args.model,
-                revision=args.revision,
-                trust_remote_code=args.trust_remote_code,
-                token=args.use_auth_token,
-                padding_side="left",  
-            )
-        else:
-            # used by default for most models
-            tokenizer = AutoTokenizer.from_pretrained(
-                args.model,
-                revision=args.revision,
-                trust_remote_code=args.trust_remote_code,
-                token=args.use_auth_token,
-                truncation_side="left",
-                padding_side="right",  
-            )
-        if not tokenizer.eos_token:
-            if tokenizer.bos_token:
-                tokenizer.eos_token = tokenizer.bos_token
-                print("bos_token used as eos_token")
+            model_kwargs = {
+                "revision": args.revision,
+                "trust_remote_code": args.trust_remote_code,
+                "token": args.use_auth_token,
+            }
+            if args.load_in_8bit:
+                print("Loading model in 8bit")
+                model_kwargs["load_in_8bit"] = args.load_in_8bit
+                model_kwargs["device_map"] = {"": accelerator.process_index}
+            elif args.load_in_4bit:
+                print("Loading model in 4bit")
+                model_kwargs["load_in_4bit"] = args.load_in_4bit
+                model_kwargs["torch_dtype"] = torch.float16
+                model_kwargs["bnb_4bit_compute_dtype"] = torch.float16
+                model_kwargs["device_map"] = {"": accelerator.process_index}
             else:
-                raise ValueError("No eos_token or bos_token found")
-        try:
-            tokenizer.pad_token = tokenizer.eos_token
+                print(f"Loading model in {args.precision}")
+                model_kwargs["torch_dtype"] = dict_precisions[args.precision]
+
+                if args.max_memory_per_gpu:
+                    if args.max_memory_per_gpu != "auto":
+                        model_kwargs["max_memory"] = get_gpus_max_memory(
+                            args.max_memory_per_gpu, accelerator.num_processes
+                        )
+                        model_kwargs["offload_folder"] = "offload"
+                    else:
+                        model_kwargs["device_map"] = "auto"
+                        print("Loading model in auto mode")
+
+            if args.modeltype == "causal":
+                model = AutoModelForCausalLM.from_pretrained(
+                    args.model,
+                    **model_kwargs,
+                )
+            elif args.modeltype == "seq2seq":
+                warnings.warn(
+                    "Seq2Seq models have only been tested for HumanEvalPack & CodeT5+ models."
+                )
+                model = AutoModelForSeq2SeqLM.from_pretrained(
+                    args.model,
+                    **model_kwargs,
+                )
+            else:
+                raise ValueError(
+                    f"Non valid modeltype {args.modeltype}, choose from: causal, seq2seq"
+                )
+
+            if args.peft_model:
+                from peft import PeftModel  # dynamic import to avoid dependency on peft
+
+                model = PeftModel.from_pretrained(model, args.peft_model)
+                print("Loaded PEFT model. Merging...")
+                model.merge_and_unload()
+                print("Merge complete.")
+
+            if args.left_padding:
+                # left padding is required for some models like chatglm3-6b
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.model,
+                    revision=args.revision,
+                    trust_remote_code=args.trust_remote_code,
+                    token=args.use_auth_token,
+                    padding_side="left",
+                )
+            else:
+                # used by default for most models
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.model,
+                    revision=args.revision,
+                    trust_remote_code=args.trust_remote_code,
+                    token=args.use_auth_token,
+                    truncation_side="left",
+                    padding_side="right",
+                )
+            if not tokenizer.eos_token:
+                if tokenizer.bos_token:
+                    tokenizer.eos_token = tokenizer.bos_token
+                    print("bos_token used as eos_token")
+                else:
+                    raise ValueError("No eos_token or bos_token found")
+            try:
+                tokenizer.pad_token = tokenizer.eos_token
             
-        # Some models like CodeGeeX2 have pad_token as a read-only property
-        except AttributeError:
-            print("Not setting pad_token to eos_token")
-            pass
-        WIZARD_LLAMA_MODELS = [
-            "WizardLM/WizardCoder-Python-34B-V1.0",
-            "WizardLM/WizardCoder-34B-V1.0",
-            "WizardLM/WizardCoder-Python-13B-V1.0"
-        ]
-        if args.model in WIZARD_LLAMA_MODELS:
-            tokenizer.bos_token = "<s>"
-            tokenizer.bos_token_id = 1
-            print("Changing bos_token to <s>")
+            # Some models like CodeGeeX2 have pad_token as a read-only property
+            except AttributeError:
+                print("Not setting pad_token to eos_token")
+                pass
+            WIZARD_LLAMA_MODELS = [
+                "WizardLM/WizardCoder-Python-34B-V1.0",
+                "WizardLM/WizardCoder-34B-V1.0",
+                "WizardLM/WizardCoder-Python-13B-V1.0"
+            ]
+            if args.model in WIZARD_LLAMA_MODELS:
+                tokenizer.bos_token = "<s>"
+                tokenizer.bos_token_id = 1
+                print("Changing bos_token to <s>")
 
         evaluator = Evaluator(accelerator, model, tokenizer, args)
 


### PR DESCRIPTION
Tested only for tasks which don't execute any generated code for now.
Things which still need to be addressed: exact mapping of generation parameters between HF and wx (and possibly support for additional ones), stop sequences and stopping criteria (used by HF models).

Example output after running: 
`python main.py --model "ibm/granite-3b-code-instruct" --tasks "conala" --top_k 1` (default `top_k=0` isn't supported by watsonx)

```
Evaluating generations...
{
  "conala": {
    "bleu": 1.893454186003354e-08,
    "precisions": [
      0.04590818363273453,
      1.0,
      1.0,
      1.0
    ],
    "brevity_penalty": 4.090555352941771e-08,
    "length_ratio": 0.055518543193426605,
    "translation_length": 500,
    "reference_length": 9006
  },
  "config": {
    "prefix": "",
    "do_sample": true,
    "temperature": 0.2,
    "top_k": 1,
    "top_p": 0.95,
    "n_samples": 1,
    "eos": "<|endoftext|>",
    "seed": 0,
    "model": "ibm/granite-3b-code-instruct",
    "modeltype": "wx",
    "peft_model": null,
    "revision": null,
    "use_auth_token": false,
    "trust_remote_code": false,
    "tasks": "conala",
    "instruction_tokens": null,
    "batch_size": 1,
    "max_length_generation": 512,
    "precision": "fp32",
    "load_in_8bit": false,
    "load_in_4bit": false,
    "left_padding": false,
    "limit": null,
    "limit_start": 0,
    "save_every_k_tasks": -1,
    "postprocess": true,
    "allow_code_execution": false,
    "generation_only": false,
    "load_generations_path": null,
    "load_data_path": null,
    "metric_output_path": "evaluation_results.json",
    "save_generations": false,
    "load_generations_intermediate_paths": null,
    "save_generations_path": "generations.json",
    "save_references": false,
    "save_references_path": "references.json",
    "prompt": "prompt",
    "max_memory_per_gpu": null,
    "check_references": false
  }
}
```