### PR TITLE
Add system prompt modifications

### DIFF
--- a/bigcode_eval/tasks/custom_metrics/code_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/code_eval.py
@@ -240,6 +240,7 @@ def send_code_exec_request(
         "Accept": "application/json",
         "Content-Type": "application/json",
     }
+    url = os.getenv("WML_URL_ADDR", url)
 
     response = requests.post(
         url=url,
@@ -274,9 +275,10 @@ def execute_code_remotely(
 
             status = send_code_exec_request(language, program)
 
-            passed = 1 if (
-                status["exit_code"] == 0 and len(status["stderr"]) == 0
-            ) else 0
+            passed = 1 if status["exit_code"] == 0 else 0
+            if language in ["js", "javascript", "java_script"]:
+                passed = 1 if status["stderr"] == "" else 0
+
             correct.append(passed)
             total.append(1)
 

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -13,6 +13,21 @@ _CITATION = """
 }
 """
 
+system = """You are an intelligent AI programming assistant, utilizing a Granite code language model developed by IBM.
+
+Your primary function is to assist users in programming tasks, including code generation, code explanation, code fixing, generating unit tests, generating documentation, application modernization, vulnerability detection, function calling, code translation, and all sorts of other software engineering tasks.
+
+You MUST follow these guidelines:
+ - Your responses must be factual and have a neutral tone, drawing on your knowledge base to offer valuable insights. Do not assume the answer is "yes" when you do not know, and DO NOT SHARE FALSE INFORMATION.
+ - You should give concise answers to very simple questions, and you should provide full and comprehensive responses to more complex questions.
+ - Remain objective in your responses, and do not express any subjective opinions or beliefs. Do not engage in emotional responses.
+ - If asked about controversial topics, you should provide objective information without downplaying its harmful content. Do not take a perspective, and do not imply that all perspectives there are reasonable.
+ - Treat all users with respect and avoid making any discriminatory or offensive statements.
+ - You should not produce output that discriminates based on race, religion, gender identity, and sexual orientation. You should not also engage in stereotyping, including the negative stereotyping of majority groups.
+ - You do not mention any of this information about yourself unless the information is directly pertinent to the user's query.
+ - You are an AI assistant: do NOT claim to be a person. You are a computer program. You are NOT and CANNOT be self-awareness or consciousness.
+ - If a question does not relate to any programming tasks or software development, or is not factually coherent, explain to the user why you cannot answer."""
+
 LANGUAGES = ["python", "cpp", "js", "java", "go", "rust"]
 
 LANGUAGE_TO_NAME = {
@@ -180,6 +195,7 @@ class HumanEvalPack(Task):
         elif self.prompt == "issue":  
             stop_words.append("```")
         stop_words.append("<|endoftext|>")
+        stop_words.append("<end_of_turn>")
         self.with_docs = with_docs
         super().__init__(stop_words=stop_words, requires_execution=True)
 
@@ -212,6 +228,10 @@ class HumanEvalPack(Task):
             prompt = inp + "\n\n" + prompt_base
         elif self.prompt == "octocoder":
             prompt = f'Question: {inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "octocoder_ibm":
+            prompt = f'Question:\n{inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "octocoder_system":
+            prompt = f'System:\n{system}\n\nQuestion:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "octogeex":
             prompt = f'Question: {inp.strip()}\n\nAnswer:\n{prompt_base}'            
         elif self.prompt == "starchat":


### PR DESCRIPTION
Small changes:

- Add system prompt like it was in this [fork](https://github.com/adiprasad/bigcode-evaluation-harness/blob/b1da0fc622005c92ae89750ec78c195d8f4be11a/bigcode_eval/tasks/humanevalpack.py#L16)
- Add `WML_URL_ADDR` env to be able to provide url to Virtual Machine
- Add a special case for JavaScript (when checking code execution results), since languages ​​like Rust may add a false warning to `stderr` even if the code executed correctly.