### PR TITLE
Accept list & dataset in HumanEvalPack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+*.xml
 
 # Translations
 *.mo

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -28,6 +28,7 @@ You MUST follow these guidelines:
  - You are an AI assistant: do NOT claim to be a person. You are a computer program. You are NOT and CANNOT be self-awareness or consciousness.
  - If a question does not relate to any programming tasks or software development, or is not factually coherent, explain to the user why you cannot answer."""
 
+system_mixtral = "Always assist with care, respect, and truth. Respond with utmost utility yet securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies promote fairness and positivity.\n\n"
 LANGUAGES = ["python", "cpp", "js", "java", "go", "rust"]
 
 LANGUAGE_TO_NAME = {
@@ -232,6 +233,8 @@ class HumanEvalPack(Task):
             prompt = f'Question:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "octocoder_system":
             prompt = f'System:\n{system}\n\nQuestion:\n{inp}\n\nAnswer:\n{prompt_base}'
+        elif self.prompt == "mixtral_system":
+            prompt = f'System:\n{system_mixtral}Question:\n{inp}\n\nAnswer:\n{prompt_base}'
         elif self.prompt == "octogeex":
             prompt = f'Question: {inp.strip()}\n\nAnswer:\n{prompt_base}'            
         elif self.prompt == "starchat":
@@ -426,7 +429,10 @@ class HumanEvalPackGenerative(HumanEvalPack):
                 [g.replace("public class Main {\n    }", "").strip() for g in gen] for gen in generations
             ]
         elif language == "go":
-            ds = self.get_dataset().select(range(len(generations)))
+            ds = self.get_dataset()
+            if not isinstance(ds, list):
+                ds = ds.select(range(len(generations)))
+            
             for gen, ref, doc in zip(generations, references, ds):
                 for line in doc["import"].split("\n"):
                     line = line.replace("import", "").replace("(", "").replace(")", "").replace('"', "").strip()
@@ -462,7 +468,10 @@ class HumanEvalPackGenerative(HumanEvalPack):
                         gen[i] = gen[i].replace("package main", "")
                     gen[i] = test_setup_str + other_pkgs_str + gen[i]
         elif language == "rust":
-            ds = self.get_dataset().select(range(len(generations)))
+            ds = self.get_dataset()
+            if not isinstance(ds, list):
+                ds = ds.select(range(len(generations)))
+
             main = "fn main(){}\n"
             for gen, doc in zip(generations, ds):
                 declaration = doc["declaration"]

--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -432,6 +432,8 @@ class HumanEvalPackGenerative(HumanEvalPack):
             ds = self.get_dataset()
             if not isinstance(ds, list):
                 ds = ds.select(range(len(generations)))
+            else:
+                ds = ds[:len(generations)]
             
             for gen, ref, doc in zip(generations, references, ds):
                 for line in doc["import"].split("\n"):
@@ -471,6 +473,8 @@ class HumanEvalPackGenerative(HumanEvalPack):
             ds = self.get_dataset()
             if not isinstance(ds, list):
                 ds = ds.select(range(len(generations)))
+            else:
+                ds = ds[:len(generations)]
 
             main = "fn main(){}\n"
             for gen, doc in zip(generations, ds):

--- a/bigcode_eval/wx_ai.py
+++ b/bigcode_eval/wx_ai.py
@@ -180,9 +180,7 @@ class WxInference:
     ) -> list[list[str]]:
         if instruction_tokens:
             predictions = [
-                _parse_instruction(
-                    prediction[0], instruction_tokens.split(",")
-                )
+                [_parse_instruction(prediction[0], instruction_tokens.split(","))]
                 for prediction in predictions
             ]
 


### PR DESCRIPTION
Thanks to that both Rust and Go can now run HumanEvalExplain without error:
```
accelerate launch main.py \                                                          
  --max_new_tokens 1024 --min_new_tokens 1 --model "ibm/granite-3b-code-instruct" \
  --limit 5 --prompt instruct \
  --tasks humanevalexplainsynthesize-rust \
  --seed 10 --do_sample False \
  --n_samples 1 \
  --batch_size 1 \
  --load_data_path generations_humanevalexplaindescribe-rust.json \
  --allow_code_execution
```